### PR TITLE
fix: broken publisher filter

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -1,6 +1,6 @@
 <div class="dropdown">
 	<div
-		x-data='dropdown(@json(['selected' => $request[$name] ?? $default, 'options' => $options]))'
+		x-data='dropdown({{ json_encode(['selected' => $request[$name] ?? $default, 'options' => $options]) }})'
 		@keydown.escape.prevent.stop="close($refs.button)"
 		@focusin.window="! $refs.panel.contains($event.target) && close()"
 		x-id="['dropdown-button']"

--- a/resources/views/components/selectable-filter.blade.php
+++ b/resources/views/components/selectable-filter.blade.php
@@ -1,11 +1,11 @@
 @if( !empty( $items ) )
 <div
 	class="side-filter selectable"
-    x-data='selectableFilters(@json([
+    x-data='selectableFilters({{ json_encode([
     	'open' => $open ?? false,
     	'items' => $items,
     	'selected' => $selected ?? []
-	]))'
+	]) }})'
 >
 	<button @click="toggle" :aria-expanded="open" type="button">
 		<span>{{ $title }}</span>


### PR DESCRIPTION
Issue #45 

This PR attempts to fix an issue when Publisher or other filters contain special characters like single/double quotes.
It just replaces `@json` directive with PHP's built in `json_encode` method since `@json` is not meant to be used with complex cases like the one we have.

### How to test

1. Add a publisher that contains single/double quotes to your book
2. Open the catalog page and make sure publishers are rendered as expected