### PR TITLE
feat: use featured image when provided

### DIFF
--- a/src/CatalogManager.php
+++ b/src/CatalogManager.php
@@ -48,7 +48,9 @@ class CatalogManager
 
 	protected function getBackgroundImage(): string
 	{
-		return plugin_dir_url(__DIR__).'assets/images/catalogbg.jpg';
+		return has_post_thumbnail()
+			? get_the_post_thumbnail_url()
+			: plugin_dir_url(__DIR__).'assets/images/catalogbg.jpg';
 	}
 
 	protected function sanitizeRequestParams($request)


### PR DESCRIPTION
Issue #13, pressbooks/pressbooks-aldine#189

This PR renders the post's featured image when available. It falls back to the default if no featured image is provided.

### How to test

1. With this plugin active, update the catalog page to add a featured image to the post
2. View the catalog page and make sure the featured image is used as the background header image.