### PR TITLE
Pbnc 55 fix language format

### DIFF
--- a/src/Books.php
+++ b/src/Books.php
@@ -302,7 +302,7 @@ class Books
 
 		return array_map(function ($book) use ($possibleLicenses, $supported_languages) {
 			$book->license = $possibleLicenses[$book->license] ?? '';
-			$book->language = $supported_languages[ $book->language ] ?? $book->language;
+			$book->language = $supported_languages[$book->language] ?? $book->language;
 
 			return $book;
 		}, $this->books);


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-network-catalog/issues/55

This tiny PR changes the way to return the language format for each book in the catalogue. Languages now are displayed in human-readable format, instead of returning the ISO 639-1 code.

### Testing
For testing, it is pretty straightforward. Just check the network catalog and make sure the languages displayed in the book card follow the supported language format in: https://github.com/pressbooks/pressbooks/blob/1ddfbb3565b0aa6ab7447653294e2b97a7706f62/inc/l10n/namespace.php#L16 