### PR TITLE
feat: add link to h5p listing page

### DIFF
--- a/resources/views/partials/book-card.blade.php
+++ b/resources/views/partials/book-card.blade.php
@@ -7,7 +7,11 @@
 		<p>
 			<span>{{ $book->license }}&nbsp;</span>
 			@if( $book->h5pCount)
-				<span>&nbsp;{{ sprintf(__('%d H5P Activities', 'pressbooks-network-catalog'), $book->h5pCount) . ' ' }}&nbsp;</span>
+				<span>
+					<a href="{{ "$book->url/h5p-listing" }}">
+						{{ sprintf(__('%d H5P Activities', 'pressbooks-network-catalog'), $book->h5pCount) . ' ' }}
+					</a>
+				</span>
 			@endif
 			<span>&nbsp;{{ $book->language }}</span>
 		</p>


### PR DESCRIPTION
Issue #95 

This PR adds a link to the H5P listing page on books which have H5Ps

**How to test**

1. Add H5P content to books
2. Visit the catalog page and make sure books which include H5Ps have a link to the H5P listing page