### PR TITLE
chore(deps): check weekly instead of daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     # Check for updates daily
     schedule:
-      interval: "daily"
+      interval: "monthly"
     allow:
       # Allow direct updates only (for packages named in package.json)
       - dependency-type: "direct"
@@ -19,7 +19,7 @@ updates:
     directory: "/"
     # Check for updates daily
     schedule:
-      interval: "daily"
+      interval: "monthly"
     allow:
       # Allow direct updates only (for packages named in composer.json)
       - dependency-type: "direct"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     # Check for updates daily
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     allow:
       # Allow direct updates only (for packages named in package.json)
       - dependency-type: "direct"
@@ -19,7 +19,7 @@ updates:
     directory: "/"
     # Check for updates daily
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     allow:
       # Allow direct updates only (for packages named in composer.json)
       - dependency-type: "direct"


### PR DESCRIPTION
This will make things a little less noisy and align the rules with Pressbooks' other Dependabot configurations.