### PR TITLE
fix: handle special chars

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,15 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         os: [ubuntu-20.04]
-        wordpress: [6.0.3]
-        experimental: [false]
+        wordpress: [6.0.3, latest]
         include:
-          - php: 8.1
-            os: ubuntu-20.04
-            wordpress: latest
-            experimental: true
+          - experimental: true
+          - experimental: false
+            php: 8.0
+            wordpress: 6.0.3
 
     name: Tests - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
 

--- a/resources/views/partials/book-card.blade.php
+++ b/resources/views/partials/book-card.blade.php
@@ -9,9 +9,9 @@
 			@if( $book->h5pCount)
 				<span>
 					<a href="{{ "$book->url/h5p-listing" }}">
-						{{ sprintf(__('%d H5P Activities', 'pressbooks-network-catalog'), $book->h5pCount) . ' ' }}
+						{{ sprintf(__('%d H5P Activities', 'pressbooks-network-catalog'), $book->h5pCount) }}
 					</a>
-				</span>
+				</span>&nbsp;
 			@endif
 			<span>&nbsp;{{ $book->language }}</span>
 		</p>

--- a/resources/views/partials/book-card.blade.php
+++ b/resources/views/partials/book-card.blade.php
@@ -3,7 +3,7 @@
 		<img src="{{ $book->cover }}" alt="{{ sprintf(__('%s book cover', 'pressbooks-network-catalog'), $book->title) }}" />
 	</div>
 	<div class="book-info">
-		<h2><a href="{{ $book->url }}">{{ $book->title }}</a></h2>
+		<h2><a href="{{ $book->url }}">{!! $book->title !!}</a></h2>
 		<p>
 			<span>{{ $book->license }}&nbsp;</span>
 			@if( $book->h5pCount)


### PR DESCRIPTION
Issue #113 

This PR aims to handle special characters when printing the book title on the new catalog page. We already handle input when users define the book title, so just unescaping the output should be fine.

**How to test**

1. Create a book that contains special characters in the title
2. Visit the catalog page and check the book title is properly displayed