### PR TITLE
fix: filter possible values that are in the catalog

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -59,16 +59,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.245.0",
+            "version": "3.247.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "8a561bf0eddee0b905153332cfcc899801d3722b"
+                "reference": "2cd51e75e753dfe1f1677bb0a2e13a9ce70cba26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/8a561bf0eddee0b905153332cfcc899801d3722b",
-                "reference": "8a561bf0eddee0b905153332cfcc899801d3722b",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2cd51e75e753dfe1f1677bb0a2e13a9ce70cba26",
+                "reference": "2cd51e75e753dfe1f1677bb0a2e13a9ce70cba26",
                 "shasum": ""
             },
             "require": {
@@ -147,9 +147,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.245.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.247.0"
             },
-            "time": "2022-11-16T19:26:45+00:00"
+            "time": "2022-11-21T21:31:13+00:00"
         },
         {
             "name": "composer/installers",
@@ -3774,12 +3774,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/pressbooks/pressbooks.git",
-                "reference": "7293aa7be9bca9485f8ec82fbb288a8ca8206ef0"
+                "reference": "f1f1ed7bb959e2c90e046cd45e592ccc71641466"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pressbooks/pressbooks/zipball/7293aa7be9bca9485f8ec82fbb288a8ca8206ef0",
-                "reference": "7293aa7be9bca9485f8ec82fbb288a8ca8206ef0",
+                "url": "https://api.github.com/repos/pressbooks/pressbooks/zipball/f1f1ed7bb959e2c90e046cd45e592ccc71641466",
+                "reference": "f1f1ed7bb959e2c90e046cd45e592ccc71641466",
                 "shasum": ""
             },
             "require": {
@@ -3808,7 +3808,7 @@
                 "pressbooks/pb-cli": "^3",
                 "scssphp/scssphp": "~1.1.0",
                 "sinergi/browser-detector": "^6.1",
-                "symfony/process": "^5.4",
+                "symfony/process": "^6.0",
                 "vanilla/htmlawed": "^2.2",
                 "vlucas/phpdotenv": "^5.4"
             },
@@ -3855,7 +3855,7 @@
                 "issues": "https://github.com/pressbooks/pressbooks/issues/",
                 "source": "https://github.com/pressbooks/pressbooks/"
             },
-            "time": "2022-11-17T06:20:07+00:00"
+            "time": "2022-11-22T18:05:33+00:00"
         },
         {
             "name": "psr/cache",
@@ -7043,21 +7043,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.11",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1"
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6e75fe6874cbc7e4773d049616ab450eff537bf1",
-                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "url": "https://api.github.com/repos/symfony/process/zipball/44270a08ccb664143dede554ff1c00aaa2247a43",
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.0.2"
             },
             "type": "library",
             "autoload": {
@@ -7085,7 +7084,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.11"
+                "source": "https://github.com/symfony/process/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -7101,7 +7100,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-27T16:58:25+00:00"
+            "time": "2022-06-27T17:10:44+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/src/Filters/Institution.php
+++ b/src/Filters/Institution.php
@@ -11,11 +11,14 @@ class Institution implements Filter
 	{
 		$institutions = get_transient('pb-network-catalog-institutions');
 
-		if ($institutions) {
+		if ($institutions !== false) {
 			return $institutions;
 		}
 
-		$codes = DataCollector::init()->getPossibleValuesFor(DataCollector::INSTITUTIONS);
+		$codes = DataCollector::init()->getPossibleValuesFor(
+			DataCollector::INSTITUTIONS,
+			$in_catalog = true
+		);
 
 		$institutions = array_reduce($codes, function ($institutions, $key) {
 			$institutions[$key] = $key;

--- a/src/Filters/License.php
+++ b/src/Filters/License.php
@@ -12,12 +12,15 @@ class License implements Filter
 	{
 		$values = get_transient('pb-network-catalog-licenses');
 
-		if ($values) {
+		if ($values !== false) {
 			return $values;
 		}
 
 		$supportedLicenses = (new Licensing)->getSupportedTypes();
-		$currentLicenses = DataCollector::init()->getPossibleValuesFor(DataCollector::LICENSE);
+		$currentLicenses = DataCollector::init()->getPossibleValuesFor(
+			DataCollector::LICENSE,
+			$in_catalog = true
+		);
 
 		$licenses = array_reduce($currentLicenses, function ($carry, $key) use ($supportedLicenses) {
 			$license = $supportedLicenses[$key] ?? ['desc' => strtoupper($key)];

--- a/src/Filters/Publisher.php
+++ b/src/Filters/Publisher.php
@@ -11,11 +11,14 @@ class Publisher implements Filter
 	{
 		$publishers = get_transient('pb-network-catalog-publishers');
 
-		if ($publishers) {
+		if ($publishers !== false) {
 			return $publishers;
 		}
 
-		$codes = DataCollector::init()->getPossibleValuesFor(DataCollector::PUBLISHER);
+		$codes = DataCollector::init()->getPossibleValuesFor(
+			DataCollector::PUBLISHER,
+			$in_catalog = true
+		);
 
 		$publishers = array_reduce($codes, function ($publishers, $key) {
 			$publishers[$key] = $key;

--- a/src/Filters/Subject.php
+++ b/src/Filters/Subject.php
@@ -12,11 +12,14 @@ class Subject implements Filter
 	{
 		$subjects = get_transient('pb-network-catalog-subjects');
 
-		if ($subjects) {
+		if ($subjects !== false) {
 			return $subjects;
 		}
 
-		$codes = DataCollector::init()->getPossibleValuesFor(DataCollector::SUBJECTS_CODES);
+		$codes = DataCollector::init()->getPossibleValuesFor(
+			DataCollector::SUBJECTS_CODES,
+			$in_catalog = true
+		);
 
 		$subjects = array_reduce($codes, function ($subjects, $key) {
 			$subjects[$key] = get_subject_from_thema($key, true);

--- a/tests/filters/InstitutionTest.php
+++ b/tests/filters/InstitutionTest.php
@@ -47,6 +47,8 @@ class InstitutionTest extends TestCase
 			get_current_blog_id()
 		);
 
+		delete_transient('pb-network-catalog-institutions');
+
 		$institutions = Institution::getPossibleValues();
 
 		$expected = [

--- a/tests/filters/InstitutionTest.php
+++ b/tests/filters/InstitutionTest.php
@@ -21,11 +21,11 @@ class InstitutionTest extends TestCase
 			Institution::getPossibleValues()
 		);
 
-		update_site_meta( 1, DataCollector::INSTITUTIONS, 'Algoma University' );
-		update_site_meta( 2, DataCollector::INSTITUTIONS, 'Algonquin College' );
+		update_site_meta(1, DataCollector::INSTITUTIONS, 'Algoma University');
+		update_site_meta(2, DataCollector::INSTITUTIONS, 'Algonquin College');
 
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
+		update_site_meta(2, DataCollector::IN_CATALOG, 0);
 
 		delete_transient('pb-network-catalog-institutions');
 
@@ -48,8 +48,8 @@ class InstitutionTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-institutions'));
 
-		update_site_meta( 1, DataCollector::INSTITUTIONS, 'Algoma University' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::INSTITUTIONS, 'Algoma University');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Institution::getPossibleValues();
 
@@ -68,8 +68,8 @@ class InstitutionTest extends TestCase
 	 */
 	public function it_does_not_query_institutions_when_there_are_cached_values(): void
 	{
-		update_site_meta( 1, DataCollector::INSTITUTIONS, 'Algoma University' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::INSTITUTIONS, 'Algoma University');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Institution::getPossibleValues();
 
@@ -77,8 +77,8 @@ class InstitutionTest extends TestCase
 			'Algoma University' => 'Algoma University',
 		];
 
-		update_site_meta( 2, DataCollector::INSTITUTIONS, 'Algonquin College' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::INSTITUTIONS, 'Algonquin College');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertEquals($expected, Institution::getPossibleValues());
 	}
@@ -89,8 +89,8 @@ class InstitutionTest extends TestCase
 	 */
 	public function it_queries_institutions_when_cache_is_cleared(): void
 	{
-		update_site_meta( 1, DataCollector::INSTITUTIONS, 'Algoma University' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::INSTITUTIONS, 'Algoma University');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Institution::getPossibleValues();
 
@@ -99,8 +99,8 @@ class InstitutionTest extends TestCase
 			'Algonquin College' => 'Algonquin College',
 		];
 
-		update_site_meta( 2, DataCollector::INSTITUTIONS, 'Algonquin College' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::INSTITUTIONS, 'Algonquin College');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		delete_transient('pb-network-catalog-institutions');
 

--- a/tests/filters/LicenseTest.php
+++ b/tests/filters/LicenseTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Filters;
 
 use Pressbooks\DataCollector\Book as DataCollector;
-use Pressbooks\Metadata;
 use PressbooksNetworkCatalog\Filters\License;
 use Tests\TestCase;
 use utilsTrait;
@@ -12,34 +11,28 @@ class LicenseTest extends TestCase
 {
 	use utilsTrait;
 
-	protected DataCollector $collector;
-
-	protected Metadata $metadata;
-
-	public function setUp(): void
-	{
-		parent::setUp();
-
-		$this->_book();
-
-		$this->_openTextbook();
-
-		$this->collector = new DataCollector;
-
-		$this->metadata = new Metadata;
-	}
-
 	/**
 	 * @test
 	 * @group filters
 	 */
 	public function it_retrieves_possible_license_values(): void
 	{
+		$this->assertEmpty(
+			License::getPossibleValues()
+		);
+
+		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
+		update_site_meta( 2, DataCollector::LICENSE, 'cc-by' );
+
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
+
+		delete_transient('pb-network-catalog-licenses');
+
 		$licenses = License::getPossibleValues();
 
 		$expected = [
 			'all-rights-reserved' => 'All Rights Reserved',
-			'cc-by' => 'CC BY (Attribution)',
 		];
 
 		$this->assertNotEmpty($licenses);
@@ -55,14 +48,20 @@ class LicenseTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-licenses'));
 
+		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+
 		License::getPossibleValues();
 
 		$expected = [
 			'all-rights-reserved' => 'All Rights Reserved',
-			'cc-by' => 'CC BY (Attribution)',
 		];
 
+		update_site_meta( 2, DataCollector::LICENSE, 'cc-by' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+
 		$this->assertNotEmpty(get_transient('pb-network-catalog-licenses'));
+
 		$this->assertEquals($expected, get_transient('pb-network-catalog-licenses'));
 	}
 
@@ -72,15 +71,17 @@ class LicenseTest extends TestCase
 	 */
 	public function it_does_not_query_licenses_when_there_are_cached_values(): void
 	{
+		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+
 		License::getPossibleValues();
 
 		$expected = [
 			'all-rights-reserved' => 'All Rights Reserved',
-			'cc-by' => 'CC BY (Attribution)',
 		];
 
-		update_post_meta($this->metadata->getMetaPostId(), 'pb_book_license', 'public-domain');
-		update_site_meta(get_current_blog_id(), 'pb_book_license', 'public-domain');
+		update_site_meta( 2, DataCollector::LICENSE, 'cc-by' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
 
 		$this->assertEquals($expected, License::getPossibleValues());
 	}
@@ -91,6 +92,9 @@ class LicenseTest extends TestCase
 	 */
 	public function it_queries_licenses_when_cache_is_cleared(): void
 	{
+		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+
 		License::getPossibleValues();
 
 		$expected = [
@@ -98,8 +102,8 @@ class LicenseTest extends TestCase
 			'public-domain' => 'Public Domain',
 		];
 
-		update_post_meta($this->metadata->getMetaPostId(), 'pb_book_license', 'public-domain');
-		update_site_meta(get_current_blog_id(), 'pb_book_license', 'public-domain');
+		update_site_meta( 2, DataCollector::LICENSE, 'public-domain' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
 
 		delete_transient('pb-network-catalog-licenses');
 

--- a/tests/filters/LicenseTest.php
+++ b/tests/filters/LicenseTest.php
@@ -21,11 +21,11 @@ class LicenseTest extends TestCase
 			License::getPossibleValues()
 		);
 
-		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
-		update_site_meta( 2, DataCollector::LICENSE, 'cc-by' );
+		update_site_meta(1, DataCollector::LICENSE, 'all-rights-reserved');
+		update_site_meta(2, DataCollector::LICENSE, 'cc-by');
 
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
+		update_site_meta(2, DataCollector::IN_CATALOG, 0);
 
 		delete_transient('pb-network-catalog-licenses');
 
@@ -48,8 +48,8 @@ class LicenseTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-licenses'));
 
-		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::LICENSE, 'all-rights-reserved');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		License::getPossibleValues();
 
@@ -57,8 +57,8 @@ class LicenseTest extends TestCase
 			'all-rights-reserved' => 'All Rights Reserved',
 		];
 
-		update_site_meta( 2, DataCollector::LICENSE, 'cc-by' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::LICENSE, 'cc-by');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertNotEmpty(get_transient('pb-network-catalog-licenses'));
 
@@ -71,8 +71,8 @@ class LicenseTest extends TestCase
 	 */
 	public function it_does_not_query_licenses_when_there_are_cached_values(): void
 	{
-		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::LICENSE, 'all-rights-reserved');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		License::getPossibleValues();
 
@@ -80,8 +80,8 @@ class LicenseTest extends TestCase
 			'all-rights-reserved' => 'All Rights Reserved',
 		];
 
-		update_site_meta( 2, DataCollector::LICENSE, 'cc-by' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::LICENSE, 'cc-by');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertEquals($expected, License::getPossibleValues());
 	}
@@ -92,8 +92,8 @@ class LicenseTest extends TestCase
 	 */
 	public function it_queries_licenses_when_cache_is_cleared(): void
 	{
-		update_site_meta( 1, DataCollector::LICENSE, 'all-rights-reserved' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::LICENSE, 'all-rights-reserved');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		License::getPossibleValues();
 
@@ -102,8 +102,8 @@ class LicenseTest extends TestCase
 			'public-domain' => 'Public Domain',
 		];
 
-		update_site_meta( 2, DataCollector::LICENSE, 'public-domain' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::LICENSE, 'public-domain');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		delete_transient('pb-network-catalog-licenses');
 

--- a/tests/filters/PublisherTest.php
+++ b/tests/filters/PublisherTest.php
@@ -21,11 +21,11 @@ class PublisherTest extends TestCase
 			Publisher::getPossibleValues()
 		);
 
-		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
-		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
+		update_site_meta(1, DataCollector::PUBLISHER, 'Pressbooks');
+		update_site_meta(2, DataCollector::PUBLISHER, 'Tolkien Publishers');
 
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
+		update_site_meta(2, DataCollector::IN_CATALOG, 0);
 
 		delete_transient('pb-network-catalog-publishers');
 
@@ -48,8 +48,8 @@ class PublisherTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-publishers'));
 
-		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::PUBLISHER, 'Pressbooks');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Publisher::getPossibleValues();
 
@@ -57,8 +57,8 @@ class PublisherTest extends TestCase
 			'Pressbooks' => 'Pressbooks',
 		];
 
-		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::PUBLISHER, 'Tolkien Publishers');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertNotEmpty(get_transient('pb-network-catalog-publishers'));
 
@@ -71,8 +71,8 @@ class PublisherTest extends TestCase
 	 */
 	public function it_does_not_query_publishers_when_there_are_cached_values(): void
 	{
-		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::PUBLISHER, 'Pressbooks');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Publisher::getPossibleValues();
 
@@ -80,8 +80,8 @@ class PublisherTest extends TestCase
 			'Pressbooks' => 'Pressbooks',
 		];
 
-		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::PUBLISHER, 'Tolkien Publishers');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertEquals($expected, Publisher::getPossibleValues());
 	}
@@ -92,8 +92,8 @@ class PublisherTest extends TestCase
 	 */
 	public function it_queries_publishers_when_cache_is_cleared(): void
 	{
-		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::PUBLISHER, 'Pressbooks');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Publisher::getPossibleValues();
 
@@ -102,8 +102,8 @@ class PublisherTest extends TestCase
 			'Tolkien Publishers' => 'Tolkien Publishers',
 		];
 
-		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::PUBLISHER, 'Tolkien Publishers');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		delete_transient('pb-network-catalog-publishers');
 

--- a/tests/filters/PublisherTest.php
+++ b/tests/filters/PublisherTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\Filters;
 
-use Pressbooks\Book;
 use Pressbooks\DataCollector\Book as DataCollector;
-use Pressbooks\Metadata;
 use PressbooksNetworkCatalog\Filters\Publisher;
 use Tests\TestCase;
 use utilsTrait;
@@ -12,19 +10,6 @@ use utilsTrait;
 class PublisherTest extends TestCase
 {
 	use utilsTrait;
-
-	protected DataCollector $collector;
-
-	protected Metadata $metadata;
-
-	public function setUp(): void
-	{
-		parent::setUp();
-
-		$this->collector = new DataCollector;
-
-		$this->metadata = new Metadata;
-	}
 
 	/**
 	 * @test
@@ -36,35 +21,18 @@ class PublisherTest extends TestCase
 			Publisher::getPossibleValues()
 		);
 
-		$this->_book();
+		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
+		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
 
-		$firstBookId = get_current_blog_id();
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
 
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Pressbooks'
-		);
-
-		$this->_book();
-
-		$secondBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Some Random Publisher'
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$firstBookId
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$secondBookId
-		);
+		delete_transient('pb-network-catalog-publishers');
 
 		$publishers = Publisher::getPossibleValues();
 
 		$expected = [
 			'Pressbooks' => 'Pressbooks',
-			'Some Random Publisher' => 'Some Random Publisher',
 		];
 
 		$this->assertNotEmpty($publishers);
@@ -80,38 +48,20 @@ class PublisherTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-publishers'));
 
-		$this->_book();
-
-		$firstBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Pressbooks'
-		);
-
-		$this->_book();
-
-		$secondBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Some Random Publisher'
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$firstBookId
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$secondBookId
-		);
+		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
 
 		Publisher::getPossibleValues();
 
 		$expected = [
 			'Pressbooks' => 'Pressbooks',
-			'Some Random Publisher' => 'Some Random Publisher',
 		];
 
+		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+
 		$this->assertNotEmpty(get_transient('pb-network-catalog-publishers'));
+
 		$this->assertEquals($expected, get_transient('pb-network-catalog-publishers'));
 	}
 
@@ -121,40 +71,17 @@ class PublisherTest extends TestCase
 	 */
 	public function it_does_not_query_publishers_when_there_are_cached_values(): void
 	{
-		$this->_book();
-
-		$firstBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Pressbooks'
-		);
-
-		$this->_book();
-
-		$secondBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Some Random Publisher'
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$firstBookId
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$secondBookId
-		);
+		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
 
 		Publisher::getPossibleValues();
 
 		$expected = [
 			'Pressbooks' => 'Pressbooks',
-			'Some Random Publisher' => 'Some Random Publisher',
 		];
 
-		update_post_meta($this->metadata->getMetaPostId(), 'pb_publisher', 'Another Random Publisher');
-
-		$this->collector->copyBookMetaIntoSiteTable($secondBookId);
+		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
 
 		$this->assertEquals($expected, Publisher::getPossibleValues());
 	}
@@ -165,43 +92,20 @@ class PublisherTest extends TestCase
 	 */
 	public function it_queries_publishers_when_cache_is_cleared(): void
 	{
-		$this->_book();
-
-		$firstBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Pressbooks'
-		);
-
-		$this->_book();
-
-		$secondBookId = get_current_blog_id();
-
-		add_post_meta(
-			$this->metadata->getMetaPostId(), 'pb_publisher', 'Some Random Publisher'
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$firstBookId
-		);
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			$secondBookId
-		);
+		update_site_meta( 1, DataCollector::PUBLISHER, 'Pressbooks' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
 
 		Publisher::getPossibleValues();
 
 		$expected = [
 			'Pressbooks' => 'Pressbooks',
-			'Another Random Publisher' => 'Another Random Publisher',
+			'Tolkien Publishers' => 'Tolkien Publishers',
 		];
 
-		update_post_meta($this->metadata->getMetaPostId(), 'pb_publisher', 'Another Random Publisher');
+		update_site_meta( 2, DataCollector::PUBLISHER, 'Tolkien Publishers' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
 
-		Book::deleteBookObjectCache();
 		delete_transient('pb-network-catalog-publishers');
-
-		$this->collector->copyBookMetaIntoSiteTable($secondBookId);
 
 		$this->assertEquals($expected, Publisher::getPossibleValues());
 	}

--- a/tests/filters/SubjectTest.php
+++ b/tests/filters/SubjectTest.php
@@ -47,6 +47,8 @@ class SubjectTest extends TestCase
 			get_current_blog_id()
 		);
 
+		delete_transient('pb-network-catalog-subjects');
+
 		$subjects = Subject::getPossibleValues();
 
 		$expected = [

--- a/tests/filters/SubjectTest.php
+++ b/tests/filters/SubjectTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Filters;
 
 use Pressbooks\DataCollector\Book as DataCollector;
-use Pressbooks\Metadata;
 use PressbooksNetworkCatalog\Filters\Subject;
 use Tests\TestCase;
 use utilsTrait;
@@ -11,21 +10,6 @@ use utilsTrait;
 class SubjectTest extends TestCase
 {
 	use utilsTrait;
-
-	protected DataCollector $collector;
-
-	protected Metadata $metadata;
-
-	public function setUp(): void
-	{
-		parent::setUp();
-
-		$this->_book();
-
-		$this->collector = new DataCollector;
-
-		$this->metadata = new Metadata;
-	}
 
 	/**
 	 * @test

--- a/tests/filters/SubjectTest.php
+++ b/tests/filters/SubjectTest.php
@@ -38,14 +38,11 @@ class SubjectTest extends TestCase
 			Subject::getPossibleValues()
 		);
 
-		$meta_id = $this->metadata->getMetaPostId();
+		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
+		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
 
-		add_post_meta($meta_id, 'pb_primary_subject', 'ABA');
-		add_post_meta($meta_id, 'pb_additional_subjects', 'AVP, AVR, AVRQ');
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			get_current_blog_id()
-		);
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
 
 		delete_transient('pb-network-catalog-subjects');
 
@@ -53,9 +50,6 @@ class SubjectTest extends TestCase
 
 		$expected = [
 			'AVRQ' => 'Mechanical musical instruments',
-			'AVR' => 'Musical instruments',
-			'AVP' => 'Musicians, singers, bands and groups',
-			'ABA' => 'Theory of art',
 		];
 
 		$this->assertNotEmpty($subjects);
@@ -71,25 +65,20 @@ class SubjectTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-subjects'));
 
-		$meta_id = $this->metadata->getMetaPostId();
-
-		add_post_meta($meta_id, 'pb_primary_subject', 'ABA');
-		add_post_meta($meta_id, 'pb_additional_subjects', 'AVP, AVR, AVRQ');
-
-		$this->collector->copyBookMetaIntoSiteTable(
-			get_current_blog_id()
-		);
+		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
 
 		Subject::getPossibleValues();
 
 		$expected = [
 			'AVRQ' => 'Mechanical musical instruments',
-			'AVR' => 'Musical instruments',
-			'AVP' => 'Musicians, singers, bands and groups',
-			'ABA' => 'Theory of art',
 		];
 
+		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+
 		$this->assertNotEmpty(get_transient('pb-network-catalog-subjects'));
+
 		$this->assertEquals($expected, get_transient('pb-network-catalog-subjects'));
 	}
 
@@ -99,28 +88,17 @@ class SubjectTest extends TestCase
 	 */
 	public function it_does_not_query_subjects_when_there_are_cached_values(): void
 	{
-		$book_id = get_current_blog_id();
-
-		$meta_id = $this->metadata->getMetaPostId();
-
-		add_post_meta($meta_id, 'pb_primary_subject', 'ABA');
-		add_post_meta($meta_id, 'pb_additional_subjects', 'AVP, AVR, AVRQ');
-
-		$this->collector->copyBookMetaIntoSiteTable($book_id);
+		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
 
 		Subject::getPossibleValues();
 
 		$expected = [
 			'AVRQ' => 'Mechanical musical instruments',
-			'AVR' => 'Musical instruments',
-			'AVP' => 'Musicians, singers, bands and groups',
-			'ABA' => 'Theory of art',
 		];
 
-		update_post_meta($meta_id, 'pb_primary_subject', 'AB');
-		update_post_meta($meta_id, 'pb_additional_subjects', 'ABC, AF, AFCC');
-
-		$this->collector->copyBookMetaIntoSiteTable($book_id);
+		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
 
 		$this->assertEquals($expected, Subject::getPossibleValues());
 	}
@@ -131,31 +109,20 @@ class SubjectTest extends TestCase
 	 */
 	public function it_queries_subjects_when_cache_is_cleared(): void
 	{
-		$book_id = get_current_blog_id();
-
-		$meta_id = $this->metadata->getMetaPostId();
-
-		add_post_meta($meta_id, 'pb_primary_subject', 'ABA');
-		add_post_meta($meta_id, 'pb_additional_subjects', 'AVP, AVR, AVRQ');
-
-		$this->collector->copyBookMetaIntoSiteTable($book_id);
+		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
+		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
 
 		Subject::getPossibleValues();
 
 		$expected = [
-			'ABC' => 'Conservation, restoration and care of artworks',
-			'AFCC' => 'Paintings and painting in watercolours or pastels',
-			'AF' => 'The Arts: art forms',
-			'AB' => 'The arts: general topics',
+			'AVRQ' => 'Mechanical musical instruments',
+			'ABA' => 'Theory of art',
 		];
 
-		update_post_meta($meta_id, 'pb_primary_subject', 'AB');
-		update_post_meta($meta_id, 'pb_additional_subjects', 'ABC, AF, AFCC');
+		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
+		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
 
-		Book::deleteBookObjectCache();
 		delete_transient('pb-network-catalog-subjects');
-
-		$this->collector->copyBookMetaIntoSiteTable($book_id);
 
 		$this->assertEquals($expected, Subject::getPossibleValues());
 	}

--- a/tests/filters/SubjectTest.php
+++ b/tests/filters/SubjectTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Filters;
 
-use Pressbooks\Book;
 use Pressbooks\DataCollector\Book as DataCollector;
 use Pressbooks\Metadata;
 use PressbooksNetworkCatalog\Filters\Subject;
@@ -38,11 +37,11 @@ class SubjectTest extends TestCase
 			Subject::getPossibleValues()
 		);
 
-		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
-		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
+		update_site_meta(1, DataCollector::SUBJECTS_CODES, 'AVRQ');
+		update_site_meta(2, DataCollector::SUBJECTS_CODES, 'ABA');
 
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 0 );
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
+		update_site_meta(2, DataCollector::IN_CATALOG, 0);
 
 		delete_transient('pb-network-catalog-subjects');
 
@@ -65,8 +64,8 @@ class SubjectTest extends TestCase
 	{
 		$this->assertEmpty(get_transient('pb-network-catalog-subjects'));
 
-		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::SUBJECTS_CODES, 'AVRQ');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Subject::getPossibleValues();
 
@@ -74,8 +73,8 @@ class SubjectTest extends TestCase
 			'AVRQ' => 'Mechanical musical instruments',
 		];
 
-		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::SUBJECTS_CODES, 'ABA');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertNotEmpty(get_transient('pb-network-catalog-subjects'));
 
@@ -88,8 +87,8 @@ class SubjectTest extends TestCase
 	 */
 	public function it_does_not_query_subjects_when_there_are_cached_values(): void
 	{
-		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::SUBJECTS_CODES, 'AVRQ');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Subject::getPossibleValues();
 
@@ -97,8 +96,8 @@ class SubjectTest extends TestCase
 			'AVRQ' => 'Mechanical musical instruments',
 		];
 
-		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::SUBJECTS_CODES, 'ABA');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		$this->assertEquals($expected, Subject::getPossibleValues());
 	}
@@ -109,8 +108,8 @@ class SubjectTest extends TestCase
 	 */
 	public function it_queries_subjects_when_cache_is_cleared(): void
 	{
-		update_site_meta( 1, DataCollector::SUBJECTS_CODES, 'AVRQ' );
-		update_site_meta( 1, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(1, DataCollector::SUBJECTS_CODES, 'AVRQ');
+		update_site_meta(1, DataCollector::IN_CATALOG, 1);
 
 		Subject::getPossibleValues();
 
@@ -119,8 +118,8 @@ class SubjectTest extends TestCase
 			'ABA' => 'Theory of art',
 		];
 
-		update_site_meta( 2, DataCollector::SUBJECTS_CODES, 'ABA' );
-		update_site_meta( 2, DataCollector::IN_CATALOG, 1 );
+		update_site_meta(2, DataCollector::SUBJECTS_CODES, 'ABA');
+		update_site_meta(2, DataCollector::IN_CATALOG, 1);
 
 		delete_transient('pb-network-catalog-subjects');
 


### PR DESCRIPTION
Fix for #131. Depends on pressbooks/pressbooks#3041.

This PR changes the behaviour when collecting possible filters to only consider values for books that are included in the network catalog.

**How to test**

1. Add books to the catalog with subjects, institutions, licenses, and publishers
2. Make sure to add distinct values (subjects, institutions, licences, or publishers) to books that are not in the catalog
3. Flush the cache to make sure queries run fresh
4. Check the catalog, filters should only show values for books that are included in the catalog