### PR TITLE
fix: properly render short description html tags

### DIFF
--- a/resources/views/partials/book-card.blade.php
+++ b/resources/views/partials/book-card.blade.php
@@ -58,7 +58,7 @@
                     @if($book->description)
                         {!! $book->description !!}
                     @elseif($book->shortDescription)
-                        {!! $book->shortDescription !!}
+                        {!! pb_decode($book->shortDescription) !!}
                     @endif
                 </div>
                 <a class="read-more" @click="window.toggleClass($el.previousElementSibling,'line-clamp'); showRead=!showRead " x-show="window.hasClampedText($el.previousElementSibling)" x-text="showRead? 'Read more' : 'Show less' "></a>


### PR DESCRIPTION
Issue #138 

This PR fixes the short description rendering not properly displaying html tag content.

**How to test**

1. Edit a book info
2. Add a short description that contains html tags
3. Visit the catalog page
4. Make sure the short description is rendered properly