### PR TITLE
fix: avoid dynamic property for Illuminate\Http\Request

### DIFF
--- a/resources/views/partials/search-box.blade.php
+++ b/resources/views/partials/search-box.blade.php
@@ -12,9 +12,9 @@
 		{{ sprintf(_n('%d result', '%d results', $pagination['total'], 'pressbooks-network-catalog'), $pagination['total']) }}
 	</span>
 @endif
-@if($request->activeFilters->isNotEmpty())
+@if($activeFilters->isNotEmpty())
 	<section class="applied-filters" x-data aria-label="{{ __('Applied filters', 'pressbooks-network-catalog') }}">
-		@foreach($request->activeFilters as $filter)
+		@foreach($activeFilters as $filter)
 			<div class="applied-filter">
 				<span>{{ pb_decode( $filter['label'] ) }}</span>
 				<button type="button" class="remove" @click="removeFilter('{{ addslashes($filter['key']) }}')">

--- a/src/CatalogManager.php
+++ b/src/CatalogManager.php
@@ -26,9 +26,6 @@ class CatalogManager
 			'publishers' => Publisher::getPossibleValues(),
 		];
 
-		// Inject active filters into the request object
-		$this->request->activeFilters = $this->getActiveFilters();
-
 		$books = new Books($this->filters);
 
 		$this->request->replace($this->sanitizeRequestParams($this->request));
@@ -39,6 +36,7 @@ class CatalogManager
 			'pagination' => $books->getPagination(),
 			'catalogBg' => $this->getBackgroundImage(),
 			'catalogHasBooks' => $books->catalogHasBooks(),
+			'activeFilters' => $this->getActiveFilters(),
 		] + $this->filters;
 	}
 


### PR DESCRIPTION
This pull request refactors how active filters are handled in the catalog search functionality by removing their injection into the request object and instead passing them explicitly to views. The changes avoid the new PHP 8.2 deprecation warnings.

Right now, we can see a warning message in the catalog:
```
Deprecated: Creation of dynamic property Illuminate\Http\Request::$activeFilters is deprecated in /app/web/app/plugins/pressbooks-network-catalog/src/CatalogManager.php on line 30
```
This is because dynamic properties are deprecated in php 8.2, see more details [here](https://php.watch/versions/8.2/dynamic-properties-deprecated).
Instead of adding dynamic property, this PR proposes send the active filters as a separate variable for the template.

### Refactoring of active filters handling:

* [`resources/views/partials/search-box.blade.php`](diffhunk://#diff-1a98908a2f3caabe622c7d7243b36b015f49a0ecb7d66922b2eafcf2e8911a58L15-R17): Replaced `$request->activeFilters` with `$activeFilters` to reflect the new approach of passing active filters explicitly to the view instead of relying on the request object.

* [`src/CatalogManager.php`](diffhunk://#diff-e97eab4a4a334a4104d0cc3bfc5b18aa9bcf7f67f3407250fecce77a50fdd23fL29-L31): Removed the injection of active filters into the request object (`$this->request->activeFilters`) and instead added `activeFilters` directly to the returned array in the `handle()` method. This ensures active filters are explicitly passed to the view. [[1]](diffhunk://#diff-e97eab4a4a334a4104d0cc3bfc5b18aa9bcf7f67f3407250fecce77a50fdd23fL29-L31) [[2]](diffhunk://#diff-e97eab4a4a334a4104d0cc3bfc5b18aa9bcf7f67f3407250fecce77a50fdd23fR39)