### PR TITLE
fix: pot workflow

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -18,4 +18,3 @@ jobs:
       slug: "pressbooks-network-catalog"
       package_name: "Pressbooks Network Catalog"
       headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks-network-catalog/issues"}'
-      pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Remove unrequired parameter on push triggers