### PR TITLE
chore: translations update from Pressbooks Weblate

### DIFF
--- a/languages/pressbooks-network-catalog-es_ES.po
+++ b/languages/pressbooks-network-catalog-es_ES.po
@@ -2,20 +2,23 @@
 # This file is distributed under the GPL v3 or later.
 # Translators:
 # Eduardo Vera, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Pressbooks Network Catalog 1.3.5\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-catalog/issues\n"
-"POT-Creation-Date: 2024-04-08T17:42:55+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-"
+"catalog/issues\n"
+"POT-Creation-Date: 2025-01-13T22:22:37+00:00\n"
 "PO-Revision-Date: 2023-03-08 01:17+0000\n"
 "Last-Translator: Eduardo Vera, 2023\n"
-"Language-Team: Spanish (https://app.transifex.com/pressbooks/teams/9194/es/)\n"
+"Language-Team: Spanish (https://app.transifex.com/pressbooks/teams/9194/"
+"es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 "X-Domain: pressbooks-network-catalog\n"
 "X-Generator: WP-CLI 2.10.0\n"
 
@@ -81,8 +84,8 @@ msgid ""
 "alternative terms with similar meanings, or clear one or more filters."
 msgstr ""
 "Lo siento, no se encontró ningún resultado. Puedes comprobar la ortografía, "
-"usar términos alternativos con un significado similar o desactivar uno o más"
-" filtros."
+"usar términos alternativos con un significado similar o desactivar uno o más "
+"filtros."
 
 #: resources/views/catalog.blade.php:42
 msgid "No books have been added to the catalog yet."

--- a/languages/pressbooks-network-catalog-fr_FR.po
+++ b/languages/pressbooks-network-catalog-fr_FR.po
@@ -2,20 +2,22 @@
 # This file is distributed under the GPL v3 or later.
 # Translators:
 # Steel Wagstaff <steel@pressbooks.com>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Pressbooks Network Catalog 1.3.5\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-catalog/issues\n"
-"POT-Creation-Date: 2024-04-08T17:42:55+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-"
+"catalog/issues\n"
+"POT-Creation-Date: 2025-01-13T22:22:37+00:00\n"
 "PO-Revision-Date: 2023-03-08 01:17+0000\n"
 "Last-Translator: Steel Wagstaff <steel@pressbooks.com>, 2023\n"
 "Language-Team: French (https://app.transifex.com/pressbooks/teams/9194/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 "X-Domain: pressbooks-network-catalog\n"
 "X-Generator: WP-CLI 2.10.0\n"
 
@@ -79,8 +81,8 @@ msgid ""
 "Sorry, no results were found. You may want to check your spelling, use "
 "alternative terms with similar meanings, or clear one or more filters."
 msgstr ""
-"Désolé, aucun résultat n'a été trouvé. Vous voudrez peut-être vérifier votre"
-" orthographe, utiliser des termes alternatifs ayant des significations "
+"Désolé, aucun résultat n'a été trouvé. Vous voudrez peut-être vérifier votre "
+"orthographe, utiliser des termes alternatifs ayant des significations "
 "similaires ou supprimer un ou plusieurs filtres."
 
 #: resources/views/catalog.blade.php:42

--- a/languages/pressbooks-network-catalog-ja.po
+++ b/languages/pressbooks-network-catalog-ja.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GPL v3 or later.
 # Translators:
 # Eduardo Vera, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Pressbooks Network Catalog 1.3.5\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-catalog/issues\n"
-"POT-Creation-Date: 2024-04-08T17:42:55+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-"
+"catalog/issues\n"
+"POT-Creation-Date: 2025-01-13T22:22:37+00:00\n"
 "PO-Revision-Date: 2023-03-08 01:17+0000\n"
 "Last-Translator: Eduardo Vera, 2023\n"
-"Language-Team: Japanese (https://app.transifex.com/pressbooks/teams/9194/ja/)\n"
+"Language-Team: Japanese (https://app.transifex.com/pressbooks/teams/9194/"
+"ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Domain: pressbooks-network-catalog\n"
 "X-Generator: WP-CLI 2.10.0\n"
@@ -33,7 +35,8 @@ msgstr "https://pressbooks.org"
 #. Description of the plugin
 #: pressbooks-network-catalog.php
 msgid "Add a searchable, filterable catalog to the Pressbooks Aldine theme"
-msgstr "Pressbooks Aldine テーマに検索・フィルター設定可能なカタログを追加します。"
+msgstr ""
+"Pressbooks Aldine テーマに検索・フィルター設定可能なカタログを追加します。"
 
 #. Author of the plugin
 #: pressbooks-network-catalog.php
@@ -78,7 +81,8 @@ msgid ""
 "Sorry, no results were found. You may want to check your spelling, use "
 "alternative terms with similar meanings, or clear one or more filters."
 msgstr ""
-"結果が見つかりませんでした。スペルを確認したり、意味の似た代替キーワードを使用したり、1つ以上の絞り込みをクリアしたりする方がよいかもしれません。"
+"結果が見つかりませんでした。スペルを確認したり、意味の似た代替キーワードを使"
+"用したり、1つ以上の絞り込みをクリアしたりする方がよいかもしれません。"
 
 #: resources/views/catalog.blade.php:42
 msgid "No books have been added to the catalog yet."

--- a/languages/pressbooks-network-catalog-tr_TR.po
+++ b/languages/pressbooks-network-catalog-tr_TR.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GPL v3 or later.
 # Translators:
 # Zeki Tuman (ztuman) <afuatdemir@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Pressbooks Network Catalog 1.3.5\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-catalog/issues\n"
-"POT-Creation-Date: 2024-04-08T17:42:55+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-"
+"catalog/issues\n"
+"POT-Creation-Date: 2025-01-13T22:22:37+00:00\n"
 "PO-Revision-Date: 2023-03-08 01:17+0000\n"
 "Last-Translator: Zeki Tuman (ztuman) <afuatdemir@gmail.com>, 2024\n"
-"Language-Team: Turkish (Turkey) (https://app.transifex.com/pressbooks/teams/9194/tr_TR/)\n"
+"Language-Team: Turkish (Turkey) (https://app.transifex.com/pressbooks/teams/"
+"9194/tr_TR/)\n"
+"Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr_TR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Domain: pressbooks-network-catalog\n"
 "X-Generator: WP-CLI 2.10.0\n"
@@ -80,8 +82,8 @@ msgid ""
 "alternative terms with similar meanings, or clear one or more filters."
 msgstr ""
 "Üzgünüz, hiçbir sonuç bulunamadı. Yazımınızı kontrol etmek veya benzer "
-"anlamlara sahip farklı terimler kullanmak ya da bir veya daha fazla filtreyi"
-" temizlemek gerekebilir."
+"anlamlara sahip farklı terimler kullanmak ya da bir veya daha fazla filtreyi "
+"temizlemek gerekebilir."
 
 #: resources/views/catalog.blade.php:42
 msgid "No books have been added to the catalog yet."

--- a/languages/pressbooks-network-catalog-zh.po
+++ b/languages/pressbooks-network-catalog-zh.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GPL v3 or later.
 # Translators:
 # fish free <winofchina@hotmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Pressbooks Network Catalog 1.3.5\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-catalog/issues\n"
-"POT-Creation-Date: 2024-04-08T17:42:55+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-network-"
+"catalog/issues\n"
+"POT-Creation-Date: 2025-01-13T22:22:37+00:00\n"
 "PO-Revision-Date: 2023-03-08 01:17+0000\n"
 "Last-Translator: fish free <winofchina@hotmail.com>, 2024\n"
-"Language-Team: Chinese (https://app.transifex.com/pressbooks/teams/9194/zh/)\n"
+"Language-Team: Chinese (https://app.transifex.com/pressbooks/teams/9194/"
+"zh/)\n"
+"Language: zh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Domain: pressbooks-network-catalog\n"
 "X-Generator: WP-CLI 2.10.0\n"
@@ -77,7 +79,9 @@ msgstr "书籍列表"
 msgid ""
 "Sorry, no results were found. You may want to check your spelling, use "
 "alternative terms with similar meanings, or clear one or more filters."
-msgstr "抱歉，未找到任何结果。您可能需要检查拼写、使用具有相似含义的替代词语或清除一个或多个筛选器。"
+msgstr ""
+"抱歉，未找到任何结果。您可能需要检查拼写、使用具有相似含义的替代词语或清除一"
+"个或多个筛选器。"
 
 #: resources/views/catalog.blade.php:42
 msgid "No books have been added to the catalog yet."


### PR DESCRIPTION
Translations update from [Pressbooks Weblate](https://translate.pressbooks.org) for [Pressbooks/Pressbooks Network Catalog](https://translate.pressbooks.org/projects/pressbooks/pressbooks-network-catalog/).



Current translation status:

![Weblate translation status](https://translate.pressbooks.org/widget/pressbooks/pressbooks-network-catalog/horizontal-auto.svg)