### PR TITLE
fix: remove deactivated books from catalog

### DIFF
--- a/src/PressbooksNetworkCatalog.php
+++ b/src/PressbooksNetworkCatalog.php
@@ -3,6 +3,8 @@
 namespace PressbooksNetworkCatalog;
 
 use Pressbooks\Container;
+use Pressbooks\DataCollector\Book;
+use function Pressbooks\Metadata\get_in_catalog_option;
 
 class PressbooksNetworkCatalog
 {
@@ -100,6 +102,15 @@ class PressbooksNetworkCatalog
 
 		add_action('init', function () {
 			load_plugin_textdomain('pressbooks-network-catalog', false, 'pressbooks-network-catalog/languages');
+		});
+
+		add_action('deactivate_blog', function ($blogId) {
+			switch_to_blog($blogId);
+
+			update_option(get_in_catalog_option(), 0);
+			update_site_meta($blogId, Book::IN_CATALOG, 0);
+
+			restore_current_blog();
 		});
 	}
 }

--- a/tests/PressbooksNetworkCatalogTest.php
+++ b/tests/PressbooksNetworkCatalogTest.php
@@ -3,8 +3,8 @@
 namespace Tests;
 
 use Pressbooks\DataCollector\Book;
-use PressbooksNetworkCatalog\PressbooksNetworkCatalog;
 use function Pressbooks\Metadata\get_in_catalog_option;
+use PressbooksNetworkCatalog\PressbooksNetworkCatalog;
 use utilsTrait;
 
 class PressbooksNetworkCatalogTest extends TestCase
@@ -60,7 +60,7 @@ class PressbooksNetworkCatalogTest extends TestCase
 		$blogId = get_current_blog_id();
 
 		update_option(get_in_catalog_option(), 1);
-		
+
 		restore_current_blog();
 
 		update_site_meta($blogId, Book::IN_CATALOG, 1);

--- a/tests/PressbooksNetworkCatalogTest.php
+++ b/tests/PressbooksNetworkCatalogTest.php
@@ -2,10 +2,15 @@
 
 namespace Tests;
 
+use Pressbooks\DataCollector\Book;
 use PressbooksNetworkCatalog\PressbooksNetworkCatalog;
+use function Pressbooks\Metadata\get_in_catalog_option;
+use utilsTrait;
 
 class PressbooksNetworkCatalogTest extends TestCase
 {
+	use utilsTrait;
+
 	public function setUp(): void
 	{
 		parent::setUp();
@@ -42,5 +47,33 @@ class PressbooksNetworkCatalogTest extends TestCase
 
 		$this->assertNotEmpty($content);
 		$this->assertStringContainsString('<div class="network-catalog">', $content);
+	}
+
+	/**
+	 * @test
+	 * @group network-catalog
+	 */
+	public function it_removes_book_from_catalog_on_blog_deactivation(): void
+	{
+		$this->_book();
+
+		$blogId = get_current_blog_id();
+
+		update_option(get_in_catalog_option(), 1);
+		
+		restore_current_blog();
+
+		update_site_meta($blogId, Book::IN_CATALOG, 1);
+
+		PressbooksNetworkCatalog::init();
+
+		do_action('deactivate_blog', $blogId);
+
+		switch_to_blog($blogId);
+		$optionValue = get_option(get_in_catalog_option());
+		restore_current_blog();
+
+		$this->assertEquals(0, $optionValue);
+		$this->assertEquals(0, get_site_meta($blogId, Book::IN_CATALOG, true));
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-network-catalog/issues/497

This pull request introduces a new hook to handle deactivation of blogs within the `PressbooksNetworkCatalog` class. When a blog is deactivated, its catalog status is updated both at the blog and network levels to ensure consistency.

**Enhancements to blog deactivation handling:**

* Added a `deactivate_blog` action in `PressbooksNetworkCatalog` to update both the blog option and network meta for catalog status when a blog is deactivated. (`src/PressbooksNetworkCatalog.php`)

**Dependency and import updates:**

* Imported `Book` from `Pressbooks\DataCollector` and the `get_in_catalog_option` function from `Pressbooks\Metadata` to support the new deactivation logic. (`src/PressbooksNetworkCatalog.php`)

### Testing notes
- deactivate a book already added in the catalog from the book list
- ensure that book is not longer in the network catalog after deactivation